### PR TITLE
Updated FPM php to cater for api gateways authorisers

### DIFF
--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -209,7 +209,8 @@ final class PhpFpm
         $request->setServerPort((int) ($headers['x-forwarded-port'][0] ?? 80));
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
-
+        $request->setCustomVar('REQUEST_CONTEXT', json_encode($event['requestContext']));
+        
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {
             $headers['content-type'] = ['application/x-www-form-urlencoded'];


### PR DESCRIPTION
This request context is needed if a user is using the authentication type of IAM_ROLE, when a user auths through Api Gateway it will then authorise the user and pass their information (securely as request context). At the moment the file misses this so a php function cant use the authorised details correctly.

Example missing data: 
` "requestContext": {
        "resourceId": "n52n1n689a",
        "resourcePath": "/",
        "httpMethod": "GET",
        "extendedRequestId": "C9gIXGW7joEFVxA=",
        "requestTime": "10/Nov/2019:20:59:33 +0000",
        "path": "/users",
        "accountId": "<REMOVED>",
        "protocol": "HTTP/1.1",
        "stage": "dev",
        "domainPrefix": "secure-api",
        "requestTimeEpoch": 1573419573440,
        "requestId": "d679114c-4a3d-42d8-862a-892d036f7e2f",
        "identity": {
            "cognitoIdentityPoolId": "<REMOVED>",
            "accountId": "<REMOVED>",
            "cognitoIdentityId": "<REMOVED>",
            "caller": "<REMOVED>",
            "sourceIp": "<REMOVED>",
            "principalOrgId": "<REMOVED>",
            "accessKey": "<REMOVED>",
            "cognitoAuthenticationType": "authenticated",
            "cognitoAuthenticationProvider": "<REMOVED>",
            "userArn": "<REMOVED>",
            "userAgent": "<REMOVED>",
            "user": "<REMOVED>"
        },
        "domainName": "<REMOVED>",
        "apiId": "<REMOVED>"
    },`
